### PR TITLE
Add FastAPI-based MaziSpace web game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+.venv/
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # MaziSpace
+
+FastAPI 기반의 싱글 플레이어 웹 게임 **MaziSpace** 입니다. 사용자는 우주선을 조작해 별을 수집하고 운석을 피하며 점수를 획득할 수 있으며, 서버와 연동된 리더보드에 점수를 기록할 수 있습니다.
+
+## 주요 특징
+
+- **FastAPI 백엔드**: 점수 제출과 리더보드 조회 API를 제공하며 CORS가 활성화되어 별도 클라이언트에서도 접근 가능합니다.
+- **Jinja 템플릿 & 정적 자원**: 서버가 메인 페이지, 스타일, JavaScript 게임 로직을 제공합니다.
+- **모던 UI**: CSS 글래스모피즘 스타일과 애니메이션을 적용해 미래지향적 분위기를 연출합니다.
+- **리더보드 관리**: 동시성 안전한 `Leaderboard` 클래스로 상위 점수를 정렬/저장합니다.
+- **테스트 커버리지**: 리더보드 로직과 FastAPI 엔드포인트에 대한 pytest 기반 테스트를 포함합니다.
+
+## 빠른 시작
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+pip install -r requirements.txt  # 또는 pyproject.toml 기반 설치
+pip install -e ".[dev]"  # 테스트 및 개발 도구 설치
+uvicorn app.main:app --reload
+```
+
+브라우저에서 [http://localhost:8000](http://localhost:8000)을 열면 게임을 플레이할 수 있습니다.
+
+## API 요약
+
+- `GET /api/leaderboard` : 현재 상위 점수 목록을 반환합니다.
+- `POST /api/leaderboard` : `{ "player_name": str, "score": int }` payload로 점수를 제출합니다.
+
+## 테스트
+
+```bash
+pytest
+```
+
+## 개발 노트
+
+- 서버 메모리에서 리더보드를 관리하므로 실제 운영 시에는 영속 저장소 연동이 필요합니다.
+- `Leaderboard` 클래스는 `max_entries` 값을 조정해 상위 N개의 점수만 유지할 수 있습니다.

--- a/app/game.py
+++ b/app/game.py
@@ -1,0 +1,55 @@
+"""게임 로직과 리더보드 관리를 담당하는 모듈."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(frozen=True, slots=True)
+class ScoreEntry:
+    """리더보드에 노출되는 점수 항목."""
+
+    player_name: str
+    score: int
+
+
+class Leaderboard:
+    """게임 점수 리더보드를 관리하는 클래스."""
+
+    def __init__(self, max_entries: int = 10) -> None:
+        self.max_entries = max_entries
+        self._entries: list[ScoreEntry] = []
+        self._lock = asyncio.Lock()
+
+    async def submit(self, player_name: str, score: int) -> List[ScoreEntry]:
+        """새로운 점수를 등록하고 현재 리더보드를 반환한다."""
+
+        if score < 0:
+            raise ValueError("점수는 0 이상이어야 합니다.")
+
+        normalized_name = player_name.strip() or "무명 파일럿"
+
+        async with self._lock:
+            entry = ScoreEntry(player_name=normalized_name[:32], score=score)
+            self._entries.append(entry)
+            self._entries.sort(key=lambda item: item.score, reverse=True)
+            self._entries = self._entries[: self.max_entries]
+            return list(self._entries)
+
+    async def entries(self) -> List[ScoreEntry]:
+        """현재 리더보드 목록을 반환한다."""
+
+        async with self._lock:
+            return list(self._entries)
+
+    async def clear(self) -> None:
+        """테스트나 초기화를 위해 리더보드를 비운다."""
+
+        async with self._lock:
+            self._entries.clear()
+
+
+leaderboard = Leaderboard()
+"""애플리케이션 전역에서 공유되는 기본 리더보드 인스턴스."""

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,75 @@
+"""FastAPI 기반 모던 웹 게임 애플리케이션."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel, Field
+
+from .game import Leaderboard, leaderboard
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+TEMPLATE_DIR = BASE_DIR / "templates"
+STATIC_DIR = BASE_DIR / "static"
+
+
+def create_app(board: Leaderboard | None = None) -> FastAPI:
+    """FastAPI 애플리케이션을 생성한다."""
+
+    app = FastAPI(title="MaziSpace", description="스페이스 러너 웹 게임", version="0.1.0")
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    static_mount = StaticFiles(directory=STATIC_DIR)
+    app.mount("/static", static_mount, name="static")
+
+    templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
+    board = board or leaderboard
+
+    class ScorePayload(BaseModel):
+        player_name: str = Field(..., max_length=32, examples=["NovaPilot"])
+        score: int = Field(..., ge=0, examples=[1280])
+
+    class ScoreResponse(BaseModel):
+        player_name: str
+        score: int
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index(request: Request) -> HTMLResponse:
+        return templates.TemplateResponse("index.html", {"request": request})
+
+    @app.get("/api/leaderboard", response_model=List[ScoreResponse])
+    async def read_leaderboard() -> List[ScoreResponse]:
+        entries = await board.entries()
+        return [ScoreResponse(player_name=item.player_name, score=item.score) for item in entries]
+
+    @app.post(
+        "/api/leaderboard",
+        response_model=List[ScoreResponse],
+        status_code=status.HTTP_201_CREATED,
+    )
+    async def submit_score(payload: ScorePayload) -> List[ScoreResponse]:
+        try:
+            entries = await board.submit(player_name=payload.player_name, score=payload.score)
+        except ValueError as exc:  # pragma: no cover - 방어적 예외 처리
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+        return [ScoreResponse(player_name=item.player_name, score=item.score) for item in entries]
+
+    return app
+
+
+app = create_app()
+"""배포 시 사용되는 기본 FastAPI 애플리케이션."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mazispace"
+version = "0.1.0"
+description = "FastAPI 기반 모던 웹 아케이드 게임"
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [
+  { name = "MaziSpace Team" },
+]
+dependencies = [
+  "fastapi>=0.110.0",
+  "uvicorn[standard]>=0.29.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0.0",
+  "httpx>=0.27.0",
+]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0

--- a/static/game.js
+++ b/static/game.js
@@ -1,0 +1,372 @@
+const canvas = document.getElementById("gameCanvas");
+const ctx = canvas.getContext("2d");
+
+const scoreEl = document.getElementById("score");
+const bestScoreEl = document.getElementById("bestScore");
+const restartButton = document.getElementById("restartButton");
+const leaderboardList = document.getElementById("leaderboard");
+const leaderboardTemplate = document.getElementById("leaderboard-item");
+const scoreForm = document.getElementById("scoreForm");
+const playerNameInput = document.getElementById("playerName");
+const gameOverDialog = document.getElementById("gameOverDialog");
+
+const API_BASE = `${window.location.origin}/api`;
+
+const state = {
+  running: true,
+  canSubmit: false,
+  score: 0,
+  bestScore: 0,
+  lastTimestamp: 0,
+  obstacleTimer: 0,
+  starTimer: 0,
+};
+
+const ship = {
+  width: 46,
+  height: 58,
+  x: canvas.width / 2 - 23,
+  y: canvas.height - 80,
+  speed: 260,
+};
+
+const input = {
+  left: false,
+  right: false,
+};
+
+const obstacles = [];
+const stars = [];
+
+function resetGame() {
+  state.running = true;
+  state.canSubmit = false;
+  state.score = 0;
+  state.obstacleTimer = 0;
+  state.starTimer = 0;
+  ship.x = canvas.width / 2 - ship.width / 2;
+  obstacles.length = 0;
+  stars.length = 0;
+  scoreEl.textContent = state.score;
+}
+
+function spawnObstacle() {
+  const width = 36 + Math.random() * 30;
+  obstacles.push({
+    x: Math.random() * (canvas.width - width),
+    y: -width,
+    width,
+    height: width,
+    speed: 120 + Math.random() * 80,
+  });
+}
+
+function spawnStar() {
+  const size = 16;
+  stars.push({
+    x: Math.random() * (canvas.width - size),
+    y: -size,
+    size,
+    speed: 80 + Math.random() * 60,
+  });
+}
+
+function updateShip(delta) {
+  if (input.left) {
+    ship.x -= ship.speed * delta;
+  }
+  if (input.right) {
+    ship.x += ship.speed * delta;
+  }
+  ship.x = Math.max(0, Math.min(canvas.width - ship.width, ship.x));
+}
+
+function updateObstacles(delta) {
+  state.obstacleTimer += delta;
+  const interval = Math.max(0.6, 1.6 - state.score / 500);
+  if (state.obstacleTimer > interval) {
+    spawnObstacle();
+    state.obstacleTimer = 0;
+  }
+
+  for (const obstacle of obstacles) {
+    obstacle.y += obstacle.speed * delta;
+  }
+
+  for (let i = obstacles.length - 1; i >= 0; i -= 1) {
+    const obstacle = obstacles[i];
+    if (obstacle.y > canvas.height + 60) {
+      obstacles.splice(i, 1);
+      continue;
+    }
+
+    if (isColliding(
+      ship.x,
+      ship.y,
+      ship.width,
+      ship.height,
+      obstacle.x,
+      obstacle.y,
+      obstacle.width,
+      obstacle.height,
+    )) {
+      endGame();
+      break;
+    }
+  }
+}
+
+function updateStars(delta) {
+  state.starTimer += delta;
+  const interval = Math.max(0.9, 2.2 - state.score / 400);
+  if (state.starTimer > interval) {
+    spawnStar();
+    state.starTimer = 0;
+  }
+
+  for (const star of stars) {
+    star.y += star.speed * delta;
+  }
+
+  for (let i = stars.length - 1; i >= 0; i -= 1) {
+    const star = stars[i];
+    if (star.y > canvas.height + star.size) {
+      stars.splice(i, 1);
+      continue;
+    }
+
+    if (
+      isColliding(
+        ship.x,
+        ship.y,
+        ship.width,
+        ship.height,
+        star.x,
+        star.y,
+        star.size,
+        star.size,
+      )
+    ) {
+      stars.splice(i, 1);
+      incrementScore(25);
+    }
+  }
+}
+
+function incrementScore(amount) {
+  state.score += amount;
+  scoreEl.textContent = state.score;
+  if (state.score > state.bestScore) {
+    state.bestScore = state.score;
+    bestScoreEl.textContent = state.bestScore;
+  }
+}
+
+function drawBackground() {
+  const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  gradient.addColorStop(0, "#0f1f3a");
+  gradient.addColorStop(1, "#040910");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.fillStyle = "rgba(255, 255, 255, 0.1)";
+  for (let i = 0; i < 80; i += 1) {
+    const x = (i * 53 + state.score) % canvas.width;
+    const y = (i * 97 + state.score * 0.4) % canvas.height;
+    ctx.fillRect(x, y, 2, 2);
+  }
+}
+
+function drawShip() {
+  ctx.fillStyle = "#ff6f91";
+  ctx.beginPath();
+  ctx.moveTo(ship.x + ship.width / 2, ship.y);
+  ctx.lineTo(ship.x + ship.width, ship.y + ship.height);
+  ctx.lineTo(ship.x, ship.y + ship.height);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = "#ffe8f0";
+  ctx.fillRect(ship.x + ship.width / 2 - 6, ship.y + ship.height / 2, 12, 16);
+}
+
+function drawObstacles() {
+  ctx.fillStyle = "#7289da";
+  obstacles.forEach((obstacle) => {
+    ctx.beginPath();
+    ctx.arc(
+      obstacle.x + obstacle.width / 2,
+      obstacle.y + obstacle.height / 2,
+      obstacle.width / 2,
+      0,
+      Math.PI * 2,
+    );
+    ctx.fill();
+  });
+}
+
+function drawStars() {
+  ctx.fillStyle = "#ffd166";
+  stars.forEach((star) => {
+    ctx.beginPath();
+    ctx.moveTo(star.x + star.size / 2, star.y);
+    for (let i = 1; i < 5; i += 1) {
+      const angle = (i * Math.PI * 2) / 5;
+      const radius = i % 2 === 0 ? star.size / 2 : star.size / 4;
+      const sx = star.x + star.size / 2 + Math.sin(angle) * radius;
+      const sy = star.y + star.size / 2 - Math.cos(angle) * radius;
+      ctx.lineTo(sx, sy);
+    }
+    ctx.closePath();
+    ctx.fill();
+  });
+}
+
+function drawGame() {
+  drawBackground();
+  drawStars();
+  drawObstacles();
+  drawShip();
+}
+
+function isColliding(ax, ay, aw, ah, bx, by, bw, bh) {
+  return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
+}
+
+function endGame() {
+  state.running = false;
+  state.canSubmit = true;
+  if (!gameOverDialog.open) {
+    gameOverDialog.showModal();
+  }
+}
+
+function gameLoop(timestamp) {
+  let delta = 0;
+  if (state.lastTimestamp) {
+    delta = (timestamp - state.lastTimestamp) / 1000;
+  }
+  state.lastTimestamp = timestamp;
+
+  if (state.running) {
+    updateShip(delta);
+    updateObstacles(delta);
+    updateStars(delta);
+  }
+
+  drawGame();
+
+  requestAnimationFrame(gameLoop);
+}
+
+function handleKeyDown(event) {
+  if (event.key === "ArrowLeft") {
+    input.left = true;
+  } else if (event.key === "ArrowRight") {
+    input.right = true;
+  }
+}
+
+function handleKeyUp(event) {
+  if (event.key === "ArrowLeft") {
+    input.left = false;
+  } else if (event.key === "ArrowRight") {
+    input.right = false;
+  }
+}
+
+async function fetchLeaderboard() {
+  try {
+    const response = await fetch(`${API_BASE}/leaderboard`);
+    if (!response.ok) {
+      throw new Error("리더보드를 불러오지 못했습니다.");
+    }
+    const data = await response.json();
+    renderLeaderboard(data);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function renderLeaderboard(entries) {
+  leaderboardList.innerHTML = "";
+  entries.forEach((entry, index) => {
+    const item = leaderboardTemplate.content.firstElementChild.cloneNode(true);
+    item.querySelector(".rank").textContent = index + 1;
+    item.querySelector(".name").textContent = entry.player_name;
+    item.querySelector(".score").textContent = entry.score.toLocaleString();
+    leaderboardList.appendChild(item);
+  });
+
+  if (!entries.length) {
+    const empty = document.createElement("li");
+    empty.textContent = "아직 기록이 없습니다.";
+    leaderboardList.appendChild(empty);
+  }
+}
+
+async function submitScore(name, score) {
+  const payload = {
+    player_name: name,
+    score,
+  };
+
+  const response = await fetch(`${API_BASE}/leaderboard`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body.detail || "점수 제출에 실패했습니다.");
+  }
+
+  const data = await response.json();
+  renderLeaderboard(data);
+  state.canSubmit = false;
+}
+
+scoreForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  if (!state.canSubmit) {
+    alert("게임이 끝난 후에만 점수를 제출할 수 있습니다.");
+    return;
+  }
+
+  const name = playerNameInput.value.trim();
+  if (!name) {
+    alert("이름을 입력하세요.");
+    return;
+  }
+
+  try {
+    await submitScore(name, state.score);
+    alert("점수가 저장되었습니다!");
+  } catch (error) {
+    alert(error.message);
+  }
+});
+
+restartButton.addEventListener("click", () => {
+  resetGame();
+  if (gameOverDialog.open) {
+    gameOverDialog.close();
+  }
+});
+
+window.addEventListener("keydown", handleKeyDown);
+window.addEventListener("keyup", handleKeyUp);
+
+gameOverDialog.addEventListener("close", () => {
+  if (!state.running) {
+    scoreForm.classList.add("highlight");
+    setTimeout(() => scoreForm.classList.remove("highlight"), 1200);
+  }
+});
+
+fetchLeaderboard();
+resetGame();
+requestAnimationFrame(gameLoop);

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,228 @@
+:root {
+  --bg-color: #050b1a;
+  --panel-color: #111b33;
+  --accent: #ff6f91;
+  --accent-strong: #ff9671;
+  --text-color: #f0f4ff;
+  --muted-text: #94a9ce;
+  --card-bg: rgba(17, 27, 51, 0.82);
+  --shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+  font-family: "Pretendard", "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #162447, var(--bg-color));
+  color: var(--text-color);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  text-align: center;
+  padding: 3rem 1rem 2rem;
+}
+
+.logo {
+  margin: 0;
+  font-size: clamp(2.4rem, 4vw, 3.2rem);
+  letter-spacing: 0.1em;
+}
+
+.tagline {
+  margin-top: 0.5rem;
+  color: var(--muted-text);
+  font-size: 1.1rem;
+}
+
+.layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(320px, 440px) minmax(240px, 340px);
+  justify-content: center;
+  padding: 0 2rem 4rem;
+}
+
+.game-panel {
+  background: var(--panel-color);
+  border-radius: 24px;
+  padding: 1.5rem 1.5rem 2rem;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+canvas {
+  width: 100%;
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(13, 24, 48, 0.9), rgba(4, 10, 24, 0.95));
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.6);
+}
+
+.hud {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.hud-item {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  border: none;
+  color: var(--text-color);
+  font-weight: 700;
+  padding: 0.7rem 1.5rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 24px rgba(255, 111, 145, 0.3);
+}
+
+.primary:focus,
+.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(255, 111, 145, 0.45);
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 20px;
+  padding: 1.5rem;
+  backdrop-filter: blur(12px);
+  box-shadow: var(--shadow);
+}
+
+.card h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.3rem;
+}
+
+.card ul {
+  padding-left: 1.2rem;
+  margin: 0;
+  color: var(--muted-text);
+}
+
+.leaderboard {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.leaderboard li {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  align-items: center;
+  padding: 0.5rem 0.8rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.leaderboard .rank {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.score-form {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.score-form input {
+  border-radius: 12px;
+  border: none;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-color);
+}
+
+.score-form input:focus {
+  outline: 2px solid var(--accent);
+}
+
+.form-hint {
+  margin-top: 0.5rem;
+  color: var(--muted-text);
+  font-size: 0.85rem;
+}
+
+.dialog::backdrop {
+  background: rgba(3, 6, 12, 0.85);
+}
+
+.dialog {
+  border: none;
+  border-radius: 24px;
+  background: var(--panel-color);
+  color: var(--text-color);
+  padding: 0;
+  box-shadow: var(--shadow);
+}
+
+.dialog-content {
+  padding: 2rem 2.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 980px) {
+  .layout {
+    grid-template-columns: minmax(320px, 1fr);
+  }
+
+  .sidebar {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .card {
+    flex: 1 1 240px;
+  }
+}
+
+@media (max-width: 680px) {
+  .layout {
+    padding: 0 1.2rem 3rem;
+  }
+
+  .sidebar {
+    flex-direction: column;
+  }
+}
+
+.score-form.highlight {
+  animation: pulse 1.2s ease;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 rgba(255, 111, 145, 0);
+  }
+  50% {
+    box-shadow: 0 0 24px rgba(255, 111, 145, 0.6);
+  }
+  100% {
+    box-shadow: 0 0 0 rgba(255, 111, 145, 0);
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MaziSpace - 스페이스 러너</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='styles.css') }}" />
+  </head>
+  <body>
+    <header class="header">
+      <h1 class="logo">🚀 MaziSpace</h1>
+      <p class="tagline">별을 수집하고 우주 쓰레기를 피하세요!</p>
+    </header>
+
+    <main class="layout">
+      <section class="game-panel">
+        <canvas id="gameCanvas" width="420" height="640" aria-label="게임 캔버스"></canvas>
+        <div class="hud">
+          <div class="hud-item">점수: <span id="score">0</span></div>
+          <div class="hud-item">최고 점수: <span id="bestScore">0</span></div>
+          <button id="restartButton" class="primary">다시 시작</button>
+        </div>
+      </section>
+
+      <section class="sidebar">
+        <article class="card">
+          <h2>조작법</h2>
+          <ul>
+            <li>◀︎ ▶︎ 키로 우주선을 이동합니다.</li>
+            <li>별을 수집하면 점수가 증가합니다.</li>
+            <li>운석에 부딪히면 게임이 종료됩니다.</li>
+          </ul>
+        </article>
+
+        <article class="card">
+          <h2>리더보드</h2>
+          <ol id="leaderboard" class="leaderboard"></ol>
+        </article>
+
+        <article class="card">
+          <h2>점수 제출</h2>
+          <form id="scoreForm" class="score-form">
+            <label for="playerName">파일럿 이름</label>
+            <input id="playerName" name="playerName" maxlength="32" placeholder="별빛 파일럿" required />
+            <button type="submit" class="primary">기록하기</button>
+          </form>
+          <p class="form-hint">게임 종료 후 점수를 제출할 수 있습니다.</p>
+        </article>
+      </section>
+    </main>
+
+    <template id="leaderboard-item">
+      <li>
+        <span class="rank"></span>
+        <span class="name"></span>
+        <span class="score"></span>
+      </li>
+    </template>
+
+    <dialog id="gameOverDialog" class="dialog">
+      <form method="dialog" class="dialog-content">
+        <h2>게임 종료</h2>
+        <p>좋은 비행이었습니다! 점수를 제출하고 랭킹에 도전하세요.</p>
+        <div class="dialog-actions">
+          <button value="close" class="primary">확인</button>
+        </div>
+      </form>
+    </dialog>
+
+    <script type="module" src="{{ url_for('static', path='game.js') }}"></script>
+  </body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+  sys.path.insert(0, str(ROOT))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+
+from app.game import Leaderboard
+from app.main import create_app
+
+
+def create_client():
+  board = Leaderboard()
+  app = create_app(board)
+  return TestClient(app), board
+
+
+def test_get_empty_leaderboard():
+  client, _ = create_client()
+  response = client.get("/api/leaderboard")
+  assert response.status_code == 200
+  assert response.json() == []
+
+
+def test_submit_score_and_fetch():
+  client, _ = create_client()
+  response = client.post("/api/leaderboard", json={"player_name": "Ace", "score": 320})
+  assert response.status_code == 201
+  data = response.json()
+  assert data[0]["player_name"] == "Ace"
+  assert data[0]["score"] == 320
+
+  response = client.post("/api/leaderboard", json={"player_name": "Nova", "score": 420})
+  assert response.status_code == 201
+  data = response.json()
+  assert [entry["player_name"] for entry in data] == ["Nova", "Ace"]
+
+  response = client.get("/api/leaderboard")
+  assert response.status_code == 200
+  assert [entry["score"] for entry in response.json()] == [420, 320]
+
+
+def test_submit_invalid_score():
+  client, _ = create_client()
+  response = client.post("/api/leaderboard", json={"player_name": "Bad", "score": -5})
+  assert response.status_code == 400
+  assert "점수" in response.json()["detail"]

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -1,0 +1,35 @@
+import asyncio
+
+from app.game import Leaderboard
+
+
+def test_submit_and_sort_leaderboard():
+  board = Leaderboard(max_entries=3)
+  asyncio.run(board.submit("Alice", 100))
+  asyncio.run(board.submit("Bob", 150))
+  asyncio.run(board.submit("Cara", 120))
+  asyncio.run(board.submit("Dan", 90))
+
+  entries = asyncio.run(board.entries())
+  assert [entry.player_name for entry in entries] == ["Bob", "Cara", "Alice"]
+  assert [entry.score for entry in entries] == [150, 120, 100]
+
+
+def test_reject_negative_scores():
+  board = Leaderboard()
+  try:
+    asyncio.run(board.submit("Test", -1))
+  except ValueError:
+    pass
+  else:
+    raise AssertionError("음수 점수는 허용되지 않아야 합니다.")
+
+
+def test_name_normalization_and_trim():
+  board = Leaderboard()
+  asyncio.run(board.submit("   ", 50))
+  asyncio.run(board.submit("VeryLongNameThatShouldBeTrimmedBeyondThirtyTwoCharacters", 60))
+
+  entries = asyncio.run(board.entries())
+  assert entries[0].player_name == "VeryLongNameThatShouldBeTrimmedBeyondThirtyTwoCharacters"[:32]
+  assert entries[1].player_name == "무명 파일럿"


### PR DESCRIPTION
## Summary
- implement a FastAPI application with leaderboard API endpoints and shared leaderboard service
- add modern single-page space runner interface with canvas gameplay, styling, and score submission logic
- document project usage, dependencies, and provide automated tests for leaderboard behavior and API contract

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi' due to missing dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0800e8fbc832c978981c3749cf5b3